### PR TITLE
Add 3d batching tensor input support for MMQ

### DIFF
--- a/hf-kernels/ggml-kernels/ggml/mmq.cu
+++ b/hf-kernels/ggml-kernels/ggml/mmq.cu
@@ -101,12 +101,25 @@ static void quantize_row_q8_1_cuda(const scalar_t* x, void* vy, const int kx,
 torch::Tensor ggml_mul_mat_a8(torch::Tensor W,  // quant weight
                               torch::Tensor X,  // input
                               int64_t type, int64_t row) {
-  int col = X.sizes()[1];
+  int64_t x_ndim = X.dim();
+  TORCH_CHECK(
+      x_ndim == 2 || x_ndim == 3,
+      "X must have shape [num_tokens, hidden_size] or [batch_size, num_tokens, hidden_size]");
+
+  int col = X.sizes()[x_ndim - 1];
   int padded = (col + 512 - 1) / 512 * 512;
-  int batch = X.sizes()[0];
   const at::cuda::OptionalCUDAGuard device_guard(device_of(X));
   auto options = torch::TensorOptions().dtype(X.dtype()).device(W.device());
-  at::Tensor Y = torch::empty({batch, row}, options);
+
+  at::Tensor Y;
+  int batch = X.numel() / col;
+  if (x_ndim == 2) {
+    Y = torch::empty({batch, row}, options);
+  }
+  else if (x_ndim == 3) {
+    Y = torch::empty({X.sizes()[0], X.sizes()[1], row}, options);
+  }
+
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   options = torch::TensorOptions().dtype(torch::kInt32).device(W.device());
   at::Tensor quant_X = torch::empty({batch, padded / 32 * 9}, options);

--- a/hf-kernels/ggml-kernels/ggml/mmq.cu
+++ b/hf-kernels/ggml-kernels/ggml/mmq.cu
@@ -112,11 +112,13 @@ torch::Tensor ggml_mul_mat_a8(torch::Tensor W,  // quant weight
   auto options = torch::TensorOptions().dtype(X.dtype()).device(W.device());
 
   at::Tensor Y;
-  int batch = X.numel() / col;
+  int batch;
   if (x_ndim == 2) {
+    batch = X.sizes()[0];
     Y = torch::empty({batch, row}, options);
   }
   else if (x_ndim == 3) {
+    batch = X.sizes()[0] * X.sizes()[1];
     Y = torch::empty({X.sizes()[0], X.sizes()[1], row}, options);
   }
 

--- a/hf-kernels/ggml-kernels/tests/kernels/test_cuda_kernels.py
+++ b/hf-kernels/ggml-kernels/tests/kernels/test_cuda_kernels.py
@@ -129,7 +129,7 @@ def test_mmq(
         )
 
 
-@pytest.mark.parametrize("batch_size", [2, 4, 8])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/hf-kernels/ggml-kernels/tests/kernels/test_cuda_kernels.py
+++ b/hf-kernels/ggml-kernels/tests/kernels/test_cuda_kernels.py
@@ -159,7 +159,7 @@ def test_mmq_batching(
     seed_everything(0)
 
     tensors = get_gguf_sample_tensors(hidden_size, quant_type)
-    x = torch.rand((batch_size, num_tokens, hidden_size), dtype=dtype, device="cuda")
+    x = torch.rand((batch_size, num_tokens, hidden_size), dtype=dtype, device="cuda") * 1e-1
     for tensor in tensors:
         weight = torch.tensor(dequantize(tensor.data, quant_type), device="cuda").to(
             dtype
@@ -169,11 +169,11 @@ def test_mmq_batching(
         qweight = torch.tensor(tensor.data, device="cuda")
         output = ops.ggml_mul_mat_a8(qweight, x, quant_type, qweight.shape[0]).to(dtype)
 
-        atols = {torch.half: 1, torch.bfloat16: 1.5, torch.float: 1.2}
+        atols = {torch.half: 1.2e-1, torch.bfloat16: 1.5, torch.float: 1.2e-1}
         # test matrix has inputs centered around 0 and lower precision from
         # bfloat16 tends to accumulate and can greatly inflate rtol
         # since outputs are also very close to 0
-        rtols = {torch.half: 1e-1, torch.bfloat16: 1e4, torch.float: 2e1}
+        rtols = {torch.half: 1e-1, torch.bfloat16: 1e-1, torch.float: 2e-1}
         torch.testing.assert_close(
             output, ref_output, atol=atols[dtype], rtol=rtols[dtype]
         )


### PR DESCRIPTION
- Support HF-style batching tensor input like `[batch, num_tokens, hidden_size]` for MMQ kernel