### PR TITLE
Optimize `get_cuda_info` overheads

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,4 @@
+## Benchmarks with Nsight Systems
+```
+nsys profile --stats=true -o mmq_benchmark python benchmarks/benchmark_mmq.py
+```

--- a/hf-kernels/ggml-kernels/ggml/kernel_instances/mmq_kernel.cuh
+++ b/hf-kernels/ggml-kernels/ggml/kernel_instances/mmq_kernel.cuh
@@ -10,8 +10,9 @@
 
 template <typename scalar_t, ggml_type type>
 void mul_mat_q_case(const mmq_args<scalar_t> & args, cudaStream_t stream) {
-    const int nsm = get_cuda_info().nsm;
-    const int cc  = get_cuda_info().cc;
+    const cuda_device_info cuda_info = get_cuda_info();
+    const int nsm = cuda_info.nsm;
+    const int cc  = cuda_info.cc;
 
     const int mmq_x_max = get_mmq_x_max_host(cc);
     const int mmq_y = get_mmq_y_host(cc, mmq_x_max);

--- a/hf-kernels/ggml-kernels/ggml/mmq.cu
+++ b/hf-kernels/ggml-kernels/ggml/mmq.cu
@@ -12,24 +12,43 @@
 
 #define MATRIX_ROW_PADDING 512 // last row of quant. matrices is a multiple of this to avoid out-of-bounds memory accesses
 
-
+// We use cudaDeviceGetAttribute() instead of cudaGetDeviceProperties() for faster query
+// see: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g49e2f8c2c0bd6fe264f2fc970912e5cd
 cuda_device_info get_cuda_info() {
     int id;
     // CUDA_CHECK(cudaGetDevice(&id));
     cudaGetDevice(&id);
 
-    cudaDeviceProp prop;
-    // CUDA_CHECK(cudaGetDeviceProperties(&prop, id));
-    cudaGetDeviceProperties(&prop, id);
+    auto get_attr = [&](cudaDeviceAttr attr) -> int {
+      int value = 0;
+      if (cudaDeviceGetAttribute(&value, attr, id) != cudaSuccess) {
+        value = 0;
+      }
+      return value;
+    };
 
+    // only cc and nsm are used for now
     cuda_device_info info;
-    info.cc = prop.major*100 + prop.minor * 10;
-    info.nsm = prop.multiProcessorCount;
-    info.smpb = prop.sharedMemPerBlock;
-    info.smpbo = prop.sharedMemPerBlockOptin;
-    info.vmm = prop.managedMemory;
-    info.vmm_granularity = prop.managedMemory ? prop.managedMemory : 0;
-    info.total_vram = prop.totalGlobalMem;
+    const int major = get_attr(cudaDevAttrComputeCapabilityMajor);
+    const int minor = get_attr(cudaDevAttrComputeCapabilityMinor);
+    info.cc = static_cast<int64_t>(major) * 100 + static_cast<int64_t>(minor) * 10;
+    info.nsm = get_attr(cudaDevAttrMultiProcessorCount);
+
+    // info.smpb = get_attr(cudaDevAttrMaxSharedMemoryPerBlock);
+    // const int smpbo = get_attr(cudaDevAttrMaxSharedMemoryPerBlockOptin);
+    // info.smpbo = smpbo ? smpbo : info.smpb;
+
+    // const int managed = get_attr(cudaDevAttrManagedMemory);
+    // info.vmm = managed;
+    // info.vmm_granularity = managed ? managed : 0;
+
+    // size_t free_bytes = 0;
+    // size_t total_bytes = 0;
+    // if (cudaMemGetInfo(&free_bytes, &total_bytes) == cudaSuccess) {
+    //   info.total_vram = total_bytes;
+    // } else {
+    //   info.total_vram = 0;
+    // }
 
     return info;
 }

--- a/hf-kernels/ggml-kernels/ggml/mmq.cu
+++ b/hf-kernels/ggml-kernels/ggml/mmq.cu
@@ -31,7 +31,7 @@ cuda_device_info get_cuda_info() {
     cuda_device_info info;
     const int major = get_attr(cudaDevAttrComputeCapabilityMajor);
     const int minor = get_attr(cudaDevAttrComputeCapabilityMinor);
-    info.cc = static_cast<int64_t>(major) * 100 + static_cast<int64_t>(minor) * 10;
+    info.cc = major * 100 + minor * 10;
     info.nsm = get_attr(cudaDevAttrMultiProcessorCount);
 
     // info.smpb = get_attr(cudaDevAttrMaxSharedMemoryPerBlock);


### PR DESCRIPTION
- `cudaGetDeviceProperties` has significant overhead to slow down MMQ kernels
- Use `cudaDeviceGetAttribute` to reduce overheads
<img width="1854" height="1048" alt="截图 2025-10-06 21-40-41" src="https://github.com/user-attachments/assets/852318b8-9a3d-4010-9c3b-9abd9a564968" />
